### PR TITLE
IRepository: changed namespace to .Domain

### DIFF
--- a/ItHappened/Domain/IRepository.cs
+++ b/ItHappened/Domain/IRepository.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using LanguageExt;
 
-namespace ItHappened.Infrastructure
+namespace ItHappened.Domain
 {
     public interface IRepository<T>
     {


### PR DESCRIPTION
SilkSlime forgot to adjust namespaces when moving IRepository from Infra to Domain